### PR TITLE
Bugfix/redirect to internal hashtags

### DIFF
--- a/src/app/directives/directive.module.ts
+++ b/src/app/directives/directive.module.ts
@@ -4,11 +4,15 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 import { ScrollNearEndDirective } from './scroll-near-end.directive';
 import { LazyLoadDirective } from './lazy-load.directive';
+import { NoteProcessorDirective } from './note-processor.directive';
+import { HrefToRouterLinkDirective } from './href-to-router-link.directive';
 
 @NgModule({
     declarations: [
         ScrollNearEndDirective,
-        LazyLoadDirective
+        LazyLoadDirective,
+        NoteProcessorDirective,
+        HrefToRouterLinkDirective
     ],
     imports: [
         BrowserModule,
@@ -17,7 +21,9 @@ import { LazyLoadDirective } from './lazy-load.directive';
     ],
     exports: [
         ScrollNearEndDirective,
-        LazyLoadDirective
+        LazyLoadDirective,
+        NoteProcessorDirective,
+        HrefToRouterLinkDirective
     ]
 })
 export class DirectivesModule { }

--- a/src/app/directives/href-to-router-link.directive.ts
+++ b/src/app/directives/href-to-router-link.directive.ts
@@ -1,0 +1,35 @@
+import { Directive, HostListener } from "@angular/core";
+import { Router } from "@angular/router";
+import { WindowService } from "../services/common/window.service";
+
+@Directive({
+    selector: '[appHrefToRouterLink]'
+  })
+  export class HrefToRouterLinkDirective {
+    constructor(private router: Router, private windowService: WindowService) {
+    }
+    
+    @HostListener('click', ['$event'])
+    onClick(event: Event) {
+        if (!(event.target instanceof HTMLAnchorElement)) {
+            return;
+        }
+  
+        const href = event.target?.getAttribute('href')?.replace(/(^\s+|\s+$)/gs, '');
+        if (!href) {
+            return;
+        }
+  
+        // If the url is not from our side we have to stop processing.
+        if (!href.startsWith('/') && !href.startsWith(this.windowService.getApplicationBaseUrl())) {
+            return;
+        }
+
+        // Stop propagation.
+        event.preventDefault();
+        event.stopPropagation();
+  
+        // Feed the router.
+        this.router.navigateByUrl(href);
+    }
+  }

--- a/src/app/directives/note-processor.directive.ts
+++ b/src/app/directives/note-processor.directive.ts
@@ -1,0 +1,52 @@
+import { Directive, Input, Inject, OnDestroy, ElementRef, NgZone, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+@Directive({
+    selector: '[appNoteProcessor]'
+})
+export class NoteProcessorDirective implements OnDestroy {
+
+    @Input('appNoteProcessor') selector?: string;
+    private observer: any;
+
+    constructor(
+        private zone: NgZone,
+        private element: ElementRef,
+        @Inject(PLATFORM_ID) private platformId: object
+    ) {
+        if (isPlatformBrowser(this.platformId)) {
+            this.zone.runOutsideAngular(() => {
+                this.observer = new MutationObserver(() =>
+                    this.addBootstrapClass(this.selector)
+                );
+
+                this.observer.observe(this.element.nativeElement, {
+                    childList: true
+                });
+            });
+        }
+    }
+
+    ngOnDestroy(): void {
+        if (this.observer) {
+            this.observer.disconnect();
+        }
+    }
+
+    private addBootstrapClass(selector?: string): void {
+        const elementsToChangeImageLinks = this.element.nativeElement.querySelectorAll(selector || 'a');
+
+        for (const item of elementsToChangeImageLinks) {
+            this.changeLinkToHashtags(item);
+        }
+    }
+
+    private changeLinkToHashtags(elementItem: HTMLAnchorElement): void {
+        const classes = elementItem.getAttribute('class');
+        if (classes?.includes('hashtag')) {
+            const hashtag = elementItem.innerText.replace('#', '');
+            elementItem.setAttribute('href', '/tags/' + hashtag);
+        }
+    }
+}
+

--- a/src/app/pages/status/status.page.html
+++ b/src/app/pages/status/status.page.html
@@ -123,7 +123,7 @@
                     <app-user-card [user]="mainStatus.user"></app-user-card>
 
                     <!-- Note -->
-                    <div class="note margin-top-10 margin-bottom-20" [innerHTML]="mainStatus.noteHtml"></div>
+                    <div id="note" class="note margin-top-10 margin-bottom-20" appNoteProcessor appHrefToRouterLink [innerHTML]="rendered"></div>
 
                     <!-- Alt text -->
                     <div *ngIf="showAlternativeText && getAltStatus(currentIndex)" class="flex-row alt margin-bottom-10">

--- a/src/app/pages/status/status.page.ts
+++ b/src/app/pages/status/status.page.ts
@@ -31,7 +31,7 @@ import { License } from 'src/app/models/license';
 import { WindowService } from 'src/app/services/common/window.service';
 import { RoutingStateService } from 'src/app/services/common/routing-state.service';
 import { DOCUMENT } from '@angular/common';
-import { Meta, Title } from '@angular/platform-browser';
+import { DomSanitizer, Meta, SafeHtml, Title } from '@angular/platform-browser';
 
 @Component({
     selector: 'app-status',
@@ -69,6 +69,7 @@ export class StatusPage extends ResponsiveComponent implements OnInit, OnDestroy
     imageHeight = 32;
     blurhash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
     isLoggedIn = false;
+    rendered?: SafeHtml = '';
 
     constructor(
         @Inject(DOCUMENT) private document: Document,
@@ -88,6 +89,7 @@ export class StatusPage extends ResponsiveComponent implements OnInit, OnDestroy
         private windowService: WindowService,
         private titleService: Title,
         private metaService: Meta,
+        private sanitizer: DomSanitizer,
         breakpointObserver: BreakpointObserver
     ) {
         super(breakpointObserver);
@@ -556,6 +558,7 @@ export class StatusPage extends ResponsiveComponent implements OnInit, OnDestroy
             return new ImageItem({ src: attachment.originalFile?.url, thumb: attachment.smallFile?.url })
         }); 
 
+        this.rendered = this.sanitizer.bypassSecurityTrustHtml(this.mainStatus?.noteHtml ?? '');
         this.comments = await this.getAllReplies(this.mainStatus.id);
     }
 


### PR DESCRIPTION
Hashtags on statuses page should redirect to internal page with statuses which contains hashtag (instead to external instance).