### PR TITLE
Reduce sticky header flickering

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,8 +1,7 @@
+<app-header></app-header>
 <main class="content mat-app-background">
-    <app-header></app-header>
-
     @if (showLoader()) {
-        <div class="loading-shade">
+        <div @fadeIn class="loading-shade">
             <mat-spinner [diameter]="36"></mat-spinner>
         </div>
     }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,5 @@
+.content {
+    position: relative;
+    width: 100%;
+    top: 64px;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,12 +6,14 @@ import { RoutingStateService } from './services/common/routing-state.service';
 import { DOCUMENT } from '@angular/common';
 import { SsrCookieService } from './services/common/ssr-cookie.service';
 import { SettingsService } from './services/http/settings.service';
+import { fadeInAnimation } from './animations/fade-in.animation';
 
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
+    animations: [fadeInAnimation],
     standalone: false
 })
 export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
@@ -34,6 +36,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
             const body = this.documentRef.getElementById('body');
             body?.classList.add('dark-theme');
             this.documentRef.querySelector("meta[name='theme-color']")?.setAttribute("content", "#303030");
+            this.documentRef.querySelector('html')?.setAttribute("class", "mat-dark");
         }
 
         const internalMastodonUrl = this.settingsService.publicSettings?.mastodonUrl ?? '';

--- a/src/app/components/core/header/header.component.scss
+++ b/src/app/components/core/header/header.component.scss
@@ -1,7 +1,15 @@
 nav {
-    position: sticky;
+    position: fixed;
     top: 0;
+    left: 0;
+    right: 0;
     z-index: 110;
+
+    ::view-transition-group(disabled),
+    ::view-transition-old(disabled),
+    ::view-transition-new(disabled) {
+        animation-duration: 0s !important;
+    }
 
     mat-toolbar {
         border: 1px solid rgba(0, 0, 0, 0.12);

--- a/src/app/components/widgets/home-signin/home-signin.component.ts
+++ b/src/app/components/widgets/home-signin/home-signin.component.ts
@@ -54,7 +54,6 @@ export class HomeSigninComponent extends ResponsiveComponent implements OnInit, 
                 const navigationEndEvent = event as NavigationEnd;
                 
                 if (navigationEndEvent.urlAfterRedirects.startsWith('/home')) {
-                    this.contextStatusesService.setContextStatuses(this.statuses());
                     this.isPageVisible = true;
                 } else {
                     this.isPageVisible = false;

--- a/src/app/components/widgets/home-signout/home-signout.component.ts
+++ b/src/app/components/widgets/home-signout/home-signout.component.ts
@@ -57,7 +57,6 @@ export class HomeSignoutComponent extends ResponsiveComponent implements OnInit,
                 const navigationEndEvent = event as NavigationEnd;
                 
                 if (navigationEndEvent.urlAfterRedirects.startsWith('/home')) {
-                    this.contextStatusesService.setContextStatuses(this.statuses());
                     this.isPageVisible = true;
                 } else {
                     this.isPageVisible = false;

--- a/src/app/pages/bookmarks/bookmarks.page.ts
+++ b/src/app/pages/bookmarks/bookmarks.page.ts
@@ -1,14 +1,13 @@
 import { Component, OnInit, OnDestroy, signal, ChangeDetectionStrategy } from '@angular/core';
 import { fadeInAnimation } from "../../animations/fade-in.animation";
 import { Status } from 'src/app/models/status';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { Subscription, filter } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { LoadingService } from 'src/app/services/common/loading.service';
 import { ResponsiveComponent } from 'src/app/common/responsive';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { LinkableResult } from 'src/app/models/linkable-result';
 import { ContextTimeline } from 'src/app/models/context-timeline';
-import { ContextStatusesService } from 'src/app/services/common/context-statuses.service';
 import { BookmarksService } from 'src/app/services/http/bookmarks.service';
 import { User } from 'src/app/models/user';
 import { AuthorizationService } from 'src/app/services/authorization/authorization.service';
@@ -33,12 +32,10 @@ export class BookmarksPage extends ResponsiveComponent implements OnInit, OnDest
     private routeNavigationEndSubscription?: Subscription;
 
     constructor(
-        private contextStatusesService: ContextStatusesService,
         private bookmarksService: BookmarksService,
         private loadingService: LoadingService,
         private authorizationService: AuthorizationService,
         private userDisplayService: UserDisplayService,
-        private router: Router,
         private activatedRoute: ActivatedRoute,
         breakpointObserver: BreakpointObserver
     ) {
@@ -47,15 +44,6 @@ export class BookmarksPage extends ResponsiveComponent implements OnInit, OnDest
 
     override async ngOnInit(): Promise<void> {
         super.ngOnInit();
-
-        this.routeNavigationEndSubscription = this.router.events
-            .pipe(filter(event => event instanceof NavigationEnd))  
-            .subscribe(async (event) => {
-                const navigationEndEvent = event as NavigationEnd;
-                if (navigationEndEvent.urlAfterRedirects === '/bookmarks') {
-                    this.contextStatusesService.setContextStatuses(this.statuses());
-                }
-            });
 
         this.routeParamsSubscription = this.activatedRoute.queryParams.subscribe(async () => {
 

--- a/src/app/pages/favourites/favourites.page.ts
+++ b/src/app/pages/favourites/favourites.page.ts
@@ -1,14 +1,13 @@
 import { Component, OnInit, OnDestroy, signal, ChangeDetectionStrategy } from '@angular/core';
 import { fadeInAnimation } from "../../animations/fade-in.animation";
 import { Status } from 'src/app/models/status';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { Subscription, filter } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { LoadingService } from 'src/app/services/common/loading.service';
 import { ResponsiveComponent } from 'src/app/common/responsive';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { LinkableResult } from 'src/app/models/linkable-result';
 import { ContextTimeline } from 'src/app/models/context-timeline';
-import { ContextStatusesService } from 'src/app/services/common/context-statuses.service';
 import { FavouritesService } from 'src/app/services/http/favourites.service';
 import { UserDisplayService } from 'src/app/services/common/user-display.service';
 import { AuthorizationService } from 'src/app/services/authorization/authorization.service';
@@ -32,12 +31,10 @@ export class FavouritesPage extends ResponsiveComponent implements OnInit, OnDes
     private routeNavigationEndSubscription?: Subscription;
 
     constructor(
-        private contextStatusesService: ContextStatusesService,
         private favouritesService: FavouritesService,
         private loadingService: LoadingService,
         private authorizationService: AuthorizationService,
         private userDisplayService: UserDisplayService,
-        private router: Router,
         private activatedRoute: ActivatedRoute,
         breakpointObserver: BreakpointObserver
     ) {
@@ -46,15 +43,6 @@ export class FavouritesPage extends ResponsiveComponent implements OnInit, OnDes
 
     override async ngOnInit(): Promise<void> {
         super.ngOnInit();
-
-        this.routeNavigationEndSubscription = this.router.events
-            .pipe(filter(event => event instanceof NavigationEnd))  
-            .subscribe(async (event) => {
-                const navigationEndEvent = event as NavigationEnd;
-                if (navigationEndEvent.urlAfterRedirects === '/favourites') {
-                    this.contextStatusesService.setContextStatuses(this.statuses());
-                }
-            });
 
         this.routeParamsSubscription = this.activatedRoute.queryParams.subscribe(async () => {
             this.loadingService.showLoader();

--- a/src/app/services/common/preferences.service.ts
+++ b/src/app/services/common/preferences.service.ts
@@ -110,9 +110,11 @@ export class PreferencesService {
         if (this.isLightTheme) {
             renderer.removeClass(this.document.body, 'dark-theme');
             this.windowService.nativeWindow.document.querySelector('meta[name="theme-color"]')?.setAttribute("content", "#fafafa");
+            this.windowService.nativeWindow.document.querySelector('html')?.removeAttribute('class');
         } else {
             renderer.addClass(this.document.body, 'dark-theme');
             this.windowService.nativeWindow.document.querySelector('meta[name="theme-color"]')?.setAttribute("content", "#303030");
+            this.windowService.nativeWindow.document.querySelector('html')?.setAttribute("class", "mat-dark");
         }
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -61,6 +61,7 @@
         const body = window.document.getElementById('body');
         body.classList.add('dark-theme');
         window.document.querySelector("meta[name='theme-color']").setAttribute("content", "#303030");
+        window.document.querySelector('html').setAttribute("class", "mat-dark");
       }
     }
   </script>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -280,7 +280,6 @@ $vernissage-dark-toolbar-theme: mat.m2-define-light-theme((
   @include notification-icons($md-notifications-dark-palette);
 }
 
-
 // =======================================================================
 // Custom fields density.
 
@@ -294,4 +293,15 @@ $vernissage-dark-toolbar-theme: mat.m2-define-light-theme((
 
 .small-button {
   @include mat.button-density(-3);
+}
+
+// =======================================================================
+// Custom route animation.
+
+html {
+  background-color: #FFFFFF;
+}
+
+.mat-dark {
+  background-color: #424242
 }


### PR DESCRIPTION
Safari on iPad blinks very often during navigation between gallery and status details (especially when we scroll the timeline). On the desktop browsers navigation looks good (especially in browser which supports ::view-transition-* animations).