### PR TITLE
Remove context statuses from local storage

### DIFF
--- a/src/app/services/common/context-statuses.service.ts
+++ b/src/app/services/common/context-statuses.service.ts
@@ -1,7 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { LinkableResult } from 'src/app/models/linkable-result';
 import { Status } from 'src/app/models/status';
-import { PersistenceService } from '../persistance/persistance.service';
 import { ContextTimeline } from 'src/app/models/context-timeline';
 import { TimelineService } from '../http/timeline.service';
 import { TrendingService } from '../http/trending.service';
@@ -18,26 +17,16 @@ export class ContextStatusesService {
     public allOlderStatusesDownloaded = false;
     public allNewerStatusesDownloaded = false;
 
-    private persistenceService = inject(PersistenceService);
     private timelineService = inject(TimelineService);
     private bookmarksService = inject(BookmarksService);
     private favouritesService = inject(FavouritesService);
     private usersService = inject(UsersService);
     private trendingService = inject(TrendingService);
 
-    constructor() {
-        const statusesFromStorage = this.persistenceService.getJson('statusesContext') as LinkableResult<Status>;
-        if (statusesFromStorage) {
-            this.statuses = statusesFromStorage;
-        }
-    }
-
     public setContextStatuses(statuses: LinkableResult<Status> | undefined): void {
         this.statuses = statuses ? LinkableResult.copy(statuses) : undefined;
         this.allOlderStatusesDownloaded = false;
         this.allNewerStatusesDownloaded = false;
-
-        this.persistenceService.setJson('statusesContext', this.statuses);
     }
 
     public clearContextStatuses(): void {
@@ -123,7 +112,6 @@ export class ContextStatusesService {
             this.statuses.data.push(...older.data);
             this.statuses.maxId = older.maxId;
 
-            this.persistenceService.setJson('statusesContext', this.statuses);
             return older;
         }
 
@@ -140,7 +128,6 @@ export class ContextStatusesService {
             this.statuses.data.unshift(...newer.data);
             this.statuses.minId = newer.minId;
 
-            this.persistenceService.setJson('statusesContext', this.statuses);
             return newer;
         }
 


### PR DESCRIPTION
We are using local storage to keep information about all current statuses displayed on the timeline. However, after loading several pages of statuses, local storage exceeds its capacity and throws an exception.

We can consider removing this functionality, as it provides only one benefit: after refreshing the status details page, we can still navigate between statuses using the arrows. However, when we go back to the timeline, we’re returned to the top of the page, which makes this feature less useful overall.