### PR TITLE
papaercut: trim whitespace from username or email field 

### DIFF
--- a/src/app/pages/login/login.page.ts
+++ b/src/app/pages/login/login.page.ts
@@ -89,7 +89,7 @@ export class LoginPage implements OnInit {
         try {
             this.clearReuseStrategyState();
 
-            const login = new Login(this.userNameOrEmail(), this.password(), this.trustMachine());
+            const login = new Login(this.userNameOrEmail().trim(), this.password(), this.trustMachine());
             const userPayloadToken = await this.accountService.login(login, this.twoFactorToken());
 
             await this.authorizationService.signIn(userPayloadToken);


### PR DESCRIPTION
Mobile keyboards often add a trailing whitespace, resulting in failed login. The register form handles this by not allowing non-alphanumeric characters. This solution is a bit more forgiving. 