### PR TITLE
Always calculate category switch on categories

### DIFF
--- a/src/app/components/widgets/category-list/category-list.component.html
+++ b/src/app/components/widgets/category-list/category-list.component.html
@@ -1,3 +1,18 @@
+<!-- Always calculate category switch -->
+<div class="category-settings margin-bottom-20">
+    <mat-slide-toggle
+        name="alwaysCalculateCategory"
+        [ngModel]="alwaysCalculateCategory()"
+        [disabled]="isSavingAlwaysCalculateCategory()"
+        (ngModelChange)="onAlwaysCalculateCategoryChange($event)">
+        {{ 'components.categoryList.texts.alwaysRecalculateRemoteStatusCategory' | translate }}
+    </mat-slide-toggle>
+    <div class="text-muted fs-90 margin-left-10 margin-top-5">
+        {{ 'components.categoryList.texts.alwaysRecalculateRemoteStatusCategoryDescription' | translate }}
+    </div>
+</div>
+
+<!-- Categories list -->
 @if (categories(); as categoriesArray) {
     <table mat-table [dataSource]="categoriesArray.data">
 

--- a/src/app/components/widgets/category-list/category-list.component.ts
+++ b/src/app/components/widgets/category-list/category-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnInit, signal } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
 import { PageEvent } from '@angular/material/paginator';
@@ -7,8 +7,10 @@ import { CategoryDialog } from 'src/app/dialogs/category-dialog/category.dialog'
 import { ConfirmationDialog } from 'src/app/dialogs/confirmation-dialog/confirmation.dialog';
 import { Category } from 'src/app/models/category';
 import { PagedResult } from 'src/app/models/paged-result';
+import { Settings } from 'src/app/models/settings';
 import { MessagesService } from 'src/app/services/common/messages.service';
 import { CategoriesService } from 'src/app/services/http/categories.service';
+import { SettingsService } from 'src/app/services/http/settings.service';
 
 @Component({
     selector: 'app-category-list',
@@ -18,8 +20,12 @@ import { CategoriesService } from 'src/app/services/http/categories.service';
     standalone: false
 })
 export class CategoryListComponent extends ResponsiveComponent implements OnInit {
+    public settings = input.required<Settings>();
+
     protected categories = signal<PagedResult<Category> | undefined>(undefined);
     protected displayedColumns = signal<string[]>([]);
+    protected alwaysCalculateCategory = signal(false);
+    protected isSavingAlwaysCalculateCategory = signal(false);
     protected pageIndex = signal(0);
 
     private pageSize = 10;
@@ -29,6 +35,7 @@ export class CategoryListComponent extends ResponsiveComponent implements OnInit
     private readonly displayedColumnsBrowser: string[] = ['categoryName', 'categoryEnabled', 'actions'];
 
     private categoriesService = inject(CategoriesService);
+    private settingsService = inject(SettingsService);
     private messageService = inject(MessagesService);
     private dialog = inject(MatDialog);
     private translateService = inject(TranslateService);
@@ -36,8 +43,31 @@ export class CategoryListComponent extends ResponsiveComponent implements OnInit
     override async ngOnInit(): Promise<void> {
         super.ngOnInit();
 
+        this.alwaysCalculateCategory.set(this.settings().alwaysCalculateCategory);
+
         const categoriesInternal = await this.categoriesService.get(this.pageIndex() + 1, this.pageSize);
         this.categories.set(categoriesInternal);
+    }
+
+    protected async onAlwaysCalculateCategoryChange(alwaysCalculateCategory: boolean): Promise<void> {
+        const previousValue = this.alwaysCalculateCategory();
+        this.alwaysCalculateCategory.set(alwaysCalculateCategory);
+        this.isSavingAlwaysCalculateCategory.set(true);
+
+        try {
+            const currentSettings = await this.settingsService.get();
+            currentSettings.alwaysCalculateCategory = alwaysCalculateCategory;
+
+            const savedSettings = await this.settingsService.put(currentSettings);
+            this.alwaysCalculateCategory.set(savedSettings.alwaysCalculateCategory);
+            this.settings().alwaysCalculateCategory = savedSettings.alwaysCalculateCategory;
+        } catch (error) {
+            this.alwaysCalculateCategory.set(previousValue);
+            console.error(error);
+            this.messageService.showServerError(error);
+        } finally {
+            this.isSavingAlwaysCalculateCategory.set(false);
+        }
     }
 
     protected async handlePageEvent(pageEvent: PageEvent): Promise<void> {

--- a/src/app/models/settings.ts
+++ b/src/app/models/settings.ts
@@ -41,6 +41,7 @@ export class Settings {
     public showSharedBusinessCards = false;
     public minimumSecondsBetweenRegularStatuses = 0;
     public minimumSecondsBetweenSilentStatuses = 0;
+    public alwaysCalculateCategory = false;
 
     public isOpenAIEnabled = false;
     public openAIKey = '';

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -70,7 +70,7 @@
                                     </mat-panel-description>
                                 }
                             </mat-expansion-panel-header>
-                            <app-category-list></app-category-list>
+                            <app-category-list [settings]="settingsObject"></app-category-list>
                         </mat-expansion-panel>
 
                         <!-- Licenses. -->

--- a/src/assets/i18n/de-de.lang
+++ b/src/assets/i18n/de-de.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Möchten Sie die Kategorie löschen?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Kategorie für Remote-Status immer neu berechnen",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Wenn diese Option aktiviert ist, werden die Kategorien eingehender ActivityPub-Statusmeldungen anhand der lokalen Regeln für Hashtag-Kategorien neu berechnet. Wird keine passende Regel gefunden, wird die vom Remote-Server bereitgestellte Kategorie verwendet.",
         "categoryName": "Name der Kategorie",
         "newCategory": "Neue Kategorie"
       }

--- a/src/assets/i18n/en-gb.lang
+++ b/src/assets/i18n/en-gb.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Do you want to delete category?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Always recalculate remote status category",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "When enabled, categories for incoming ActivityPub statuses are recalculated from the local hashtag category rules. If no matching rule is found, the category provided by the remote server is used.",
         "categoryName": "Category name",
         "newCategory": "New category"
       }

--- a/src/assets/i18n/en-us.lang
+++ b/src/assets/i18n/en-us.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Do you want to delete category?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Always recalculate remote status category",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "When enabled, categories for incoming ActivityPub statuses are recalculated from the local hashtag category rules. If no matching rule is found, the category provided by the remote server is used.",
         "categoryName": "Category name",
         "newCategory": "New category"
       }

--- a/src/assets/i18n/es-es.lang
+++ b/src/assets/i18n/es-es.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "¿Quieres eliminar categoría?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Recalcular siempre la categoría de los estados remotos",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Cuando esta opción está activada, las categorías de los estados de ActivityPub entrantes se recalculan según las reglas locales de categorías de hashtags. Si no se encuentra ninguna regla coincidente, se utiliza la categoría proporcionada por el servidor remoto.",
         "categoryName": "Nombre de categoría",
         "newCategory": "Nueva categoría"
       }

--- a/src/assets/i18n/fi-fi.lang
+++ b/src/assets/i18n/fi-fi.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Haluatko poistaa luokan?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Laske etäpalvelimelta tulevien tilapäivitysten luokka aina uudelleen",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Kun asetus on käytössä, saapuvien ActivityPub-tilapäivitysten luokat lasketaan uudelleen paikallisten aihetunnisteiden luokittelusääntöjen perusteella. Jos vastaavaa sääntöä ei löydy, käytetään etäpalvelimen ilmoittamaa luokkaa.",
         "categoryName": "Luokan nimi",
         "newCategory": "Uusi luokka"
       }

--- a/src/assets/i18n/fr-fr.lang
+++ b/src/assets/i18n/fr-fr.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Voulez-vous supprimer la catégorie ?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Toujours recalculer la catégorie des statuts distants",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Lorsque cette option est activée, les catégories des statuts ActivityPub entrants sont recalculées à partir des règles locales de catégorisation des hashtags. Si aucune règle correspondante n’est trouvée, la catégorie fournie par le serveur distant est utilisée.",
         "categoryName": "Nom de la catégorie",
         "newCategory": "Nouvelle catégorie"
       }

--- a/src/assets/i18n/it-it.lang
+++ b/src/assets/i18n/it-it.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Vuoi eliminare la categoria?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Ricalcola sempre la categoria degli stati remoti",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Quando questa opzione è abilitata, le categorie degli stati ActivityPub in arrivo vengono ricalcolate in base alle regole locali per le categorie degli hashtag. Se non viene trovata alcuna regola corrispondente, viene utilizzata la categoria fornita dal server remoto.",
         "categoryName": "Nome della categoria",
         "newCategory": "Nuova categoria"
       }

--- a/src/assets/i18n/nb-no.lang
+++ b/src/assets/i18n/nb-no.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Vil du slette kategorien?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Beregn alltid kategorien for eksterne statuser på nytt",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Når dette er aktivert, beregnes kategoriene for innkommende ActivityPub-statuser på nytt ut fra de lokale reglene for emneknaggkategorier. Hvis ingen samsvarende regel blir funnet, brukes kategorien fra den eksterne serveren.",
         "categoryName": "Kategorinavn",
         "newCategory": "Ny kategori"
       }

--- a/src/assets/i18n/pl-pl.lang
+++ b/src/assets/i18n/pl-pl.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Czy chcesz usunąć kategorię?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Zawsze przeliczaj kategorię zdalnego statusu",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Gdy opcja jest włączona, kategorie przychodzących statusów ActivityPub są ponownie wyznaczane na podstawie lokalnych reguł kategorii hashtagów. Jeśli nie zostanie znaleziona pasująca reguła, używana jest kategoria przekazana przez zdalny serwer.",
         "categoryName": "Nazwa kategorii",
         "newCategory": "Nowa kategoria"
       }

--- a/src/assets/i18n/pt-pt.lang
+++ b/src/assets/i18n/pt-pt.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Deseja eliminar a categoria?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Recalcular sempre a categoria dos estados remotos",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "Quando esta opção está ativada, as categorias dos estados ActivityPub recebidos são recalculadas com base nas regras locais de categorias de hashtags. Se não for encontrada nenhuma regra correspondente, é utilizada a categoria fornecida pelo servidor remoto.",
         "categoryName": "Nome da categoria",
         "newCategory": "Nova categoria"
       }

--- a/src/assets/i18n/sv-se.lang
+++ b/src/assets/i18n/sv-se.lang
@@ -244,6 +244,8 @@
         "doYouWantToDeleteCategory": "Vill du ta bort kategori?"
       },
       "texts": {
+        "alwaysRecalculateRemoteStatusCategory": "Beräkna alltid om kategorin för fjärrstatusar",
+        "alwaysRecalculateRemoteStatusCategoryDescription": "När detta är aktiverat beräknas kategorierna för inkommande ActivityPub-statusar om utifrån de lokala reglerna för hashtaggskategorier. Om ingen matchande regel hittas används kategorin från fjärrservern.",
         "categoryName": "Kategorinamn",
         "newCategory": "Ny kategori"
       }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
     production: false,
-    version: '1.40.0-buildx'
+    version: '1.41.0-buildx'
 };
 
 /*


### PR DESCRIPTION
Administrator can enabled recalculation of categories (based on categories rules) for all remote statuses (even id they contains already category).